### PR TITLE
fix: add strip method to delete spaces in the input URL string

### DIFF
--- a/app/controllers/job_roles_controller.rb
+++ b/app/controllers/job_roles_controller.rb
@@ -13,7 +13,7 @@ class JobRolesController < ApplicationController
 
 
   def index
-    @url =  params[:url]
+    @url =  params[:url].strip
 
     if @url.include?("https://rubyonremote.com/jobs/") || @url.include?("https://jobs.gorails.com/jobs/") && @url != nil
       scrap_job_role(@url)


### PR DESCRIPTION
- Add strip method to the URL input string in case of extra leading or trailing spaces that were leading to errors.