### PR TITLE
refactor: increment max number of tokens for job role summary

### DIFF
--- a/app/controllers/job_roles_controller.rb
+++ b/app/controllers/job_roles_controller.rb
@@ -96,8 +96,8 @@ class JobRolesController < ApplicationController
       
         # Using Gemini AI to get a summary of the Job description, as the Notion API has a limit of 2000 characters for Text fields
         loop do 
-          to_summarize = client.generate_content( { contents: { role: 'user', parts: { text: "Please summarize the following text up to 1800 characters maximum (this condition is CRITICAL: you can't surpass the 1800 characters) getting the most important information like Requirements, Benefits and Responsabilities. NOTICE: DO NOT include a note clarifying that you respected the 1800 characters limit nor indicating the total number of characters, because it sums and affects the final count of characters: #{@job_description} " }  }, generationConfig: { maxOutputTokens: 400 } } )
-          @job_role_summary = to_summarize["candidates"][0]["content"]["parts"][0]["text"].strip!
+          raw_summary = client.generate_content( { contents: { role: 'user', parts: { text: "Please summarize the following text up to 1800 characters maximum (this condition is CRITICAL: you can't surpass the 1800 characters) getting the most important information like Requirements, Benefits and Responsabilities. NOTICE: DO NOT include a note clarifying that you respected the 1800 characters limit nor indicating the total number of characters, because it sums and affects the final count of characters: #{@job_description} " }  }, generationConfig: { maxOutputTokens: 600 } } )
+          @job_role_summary = raw_summary["candidates"][0]["content"]["parts"][0]["text"].strip!
           break if @job_role_summary.size < 2000
           puts "The job Role Summary is #{@job_role_summary.size}"
         end


### PR DESCRIPTION
- Increment the job_role_summary maxOutputTokens up to 600 tokens
- Change the "to_summarize" to "raw_summary" for better legibility