### PR TITLE
hotfix: upgrade gemini-ai model to gemini-2.0-flash

### DIFF
--- a/app/controllers/job_roles_controller.rb
+++ b/app/controllers/job_roles_controller.rb
@@ -92,7 +92,7 @@ class JobRolesController < ApplicationController
           service: 'generative-language-api',
           api_key: ENV['GOOGLE_API_KEY']
         },
-        options: { model: 'gemini-1.5-flash', server_sent_events: true }
+        options: { model: 'gemini-2.0-flash', server_sent_events: true }
         )
       
         # Using Gemini AI to get a summary of the Job description, as the Notion API has a limit of 2000 characters for Text fields


### PR DESCRIPTION
Upgrade gemini-ai model to "gemini-2.0-flash" as "gemini-1.5-flash" was deprecated on May 27, 2025.

https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions

"Hello Google AI Studio developer,

We're writing to inform you that the following Gemini 1.5 models will be discontinued and will start returning errors on the dates indicated below:

May 27, 2025: Gemini 1.5 Pro 001, Gemini 1.5 Flash 001, and tuned versions of Gemini 1.5 Flash 001. [...]"