### PR TITLE
style: changing word on main title on homepage

### DIFF
--- a/app/views/job_roles/home.html.erb
+++ b/app/views/job_roles/home.html.erb
@@ -1,4 +1,4 @@
-<h1 class="mx-auto my-10 max-w-2xl text-4xl font-bold tracking-tight text-white sm:text-4xl">  Check the best Ruby Job Roles and save some in your <%=link_to "Notion", ENV['NOTION_DB_VIEW'], target: "_blank", class:"underline underline-offset-8" %> ! </h1>
+<h1 class="mx-auto my-10 max-w-2xl text-4xl font-bold tracking-tight text-white sm:text-4xl">  Check the best Ruby Job Roles and save them in your <%=link_to "Notion", ENV['NOTION_DB_VIEW'], target: "_blank", class:"underline underline-offset-8" %> ! </h1>
 
 <div class="flex justify-center h-[10rem] items-center"> 
     <div  class="block w-[50rem] rounded-lg bg-slate-600 text-white text-surface shadow-secondary-1 dark:bg-surface-dark dark:text-white">


### PR DESCRIPTION
Changing the word "some" for "them" in the phrase: 
"Check the best Ruby Job roles and save **some** in your Notion!" on the homepage to provide a clear message